### PR TITLE
feat: add `tag show` command

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,14 @@ tasks.test {
     useJUnitPlatform()
 }
 
-kotlin {
-    jvmToolchain(17)
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.compileKotlin {
+    kotlinOptions {
+        javaParameters = true
+        jvmTarget = "17"
+    }
 }

--- a/src/main/kotlin/io/github/seggan/notwalshbot/commands/TagCommand.kt
+++ b/src/main/kotlin/io/github/seggan/notwalshbot/commands/TagCommand.kt
@@ -28,6 +28,9 @@ object TagCommand : CommandExecutor("tag", "Tag management") {
             string("name", "The name of the alias") { required = true }
             string("target", "The name of the target tag") { required = true }
         }
+        subCommand("show", "Shows a tag") {
+            string("name", "The name of the tag") { required = true }
+        }
     }
 
     override val permission = Roles.addonDeveloper
@@ -124,6 +127,12 @@ object TagCommand : CommandExecutor("tag", "Tag management") {
                 Tags[name!!] = Tag.Alias(name, target)
                 Tags.save()
                 interaction.respondPublic("Alias `$name` created for `$target`")
+            }
+
+            "show" -> {
+                val tagName = command.strings["name"]!!
+                val tag = Tags[tagName]?.content ?: "Tag not found"
+                interaction.respondPublic(tag)
             }
         }
     }


### PR DESCRIPTION
This PR adds a command `tag show` which simply shows tha tag content.

The reason I make this PR is there are people who respond to your tag call (the `?tag` message) and they may think I am asking a question since the question mark is in the beginning. Using this command instead of use `?tag` message MAY avoid the confusion.

Not tested yet.